### PR TITLE
Fixed popup bug when using ajax content type

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -175,11 +175,21 @@ MagnificPopup.prototype = {
 				if(mfp.st.closeOnContentClick) {
 					mfp.close();
 				} else {
+					// determine if click is contained in content
+					var containsContent = false;
+					if (mfp.content) {
+						$.each(mfp.content, function(index, oneContent) {
+							if ($.contains(oneContent, target)) {
+								containsContent = true;
+							}
+						});
+					}
+
 					// close popup if click is not on a content, on close button, or content does not exist
 					if( !mfp.content || 
 						$(target).hasClass('mfp-close') ||
 						(mfp.preloader && e.target === mfp.preloader[0]) || 
-						(target !== mfp.content[0] && !$.contains(mfp.content[0], target)) ) {
+						(target !== mfp.content[0] && !containsContent) ) {
 						mfp.close();
 					}
 				}


### PR DESCRIPTION
So I was using the plugin to display some ajax content and noticed that somehow clicking anywhere on my popup content will close the popup (I had `closeOnContentClick` set to `false`).

Investigated and realized that's because my ajax content's got a bunch of nodes (not just one parent node that gets included by magnific popup). However magnific popup only checks for the first node of the content `mfp.content[0] && !$.contains(mfp.content[0], target)` to see if the target is contained in the content.

Just looping through all the nodes of the content to check for `contains` fixed it for me.
