### PR TITLE
Removed navigation (next/prev arrows) on the gallery when there is only one image in the gallery

### DIFF
--- a/src/js/gallery.js
+++ b/src/js/gallery.js
@@ -11,7 +11,7 @@ var _getLoopedId = function(index) {
 		return index;
 	},
 	_replaceCurrTotal = function(text, curr, total) {
-		return text.replace('%curr%', curr + 1).replace('%total%', total);
+		return (total == 1) ? '' : text.replace('%curr%', curr + 1).replace('%total%', total);
 	};
 
 $.magnificPopup.registerModule('gallery', {


### PR DESCRIPTION
A check is done for the number of images just before the arrows are rendered, and on clicking the close button
(Was a request in the issues)
