### PR TITLE
Added option for modal-like popups

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -201,7 +201,13 @@ MagnificPopup.prototype = {
 
 		mfp.st = $.extend(true, {}, $.magnificPopup.defaults, data ); 
 		mfp.fixedContentPos = mfp.st.fixedContentPos === 'auto' ? !mfp.probablyMobile : mfp.st.fixedContentPos;
-		
+
+		if(mfp.st.modal) {
+			mfp.st.closeOnContentClick = false;
+			mfp.st.closeOnBgClick = false;
+			mfp.st.showCloseBtn = false;
+			mfp.st.enableEscapeKey = false;
+		}
 		
 
 		// Building markup
@@ -238,14 +244,16 @@ MagnificPopup.prototype = {
 		_mfpTrigger('BeforeOpen');
 
 
-		// Close button
-		if(!mfp.st.closeBtnInside) {
-			mfp.wrap.append( _getCloseBtn() );
-		} else {
-			_mfpOn(MARKUP_PARSE_EVENT, function(e, template, values, item) {
-				values.close_replaceWith = _getCloseBtn(item.type);
-			});
-			_wrapClasses += ' mfp-close-btn-in';
+		if(mfp.st.showCloseBtn) {
+			// Close button
+			if(!mfp.st.closeBtnInside) {
+				mfp.wrap.append( _getCloseBtn() );
+			} else {
+				_mfpOn(MARKUP_PARSE_EVENT, function(e, template, values, item) {
+					values.close_replaceWith = _getCloseBtn(item.type);
+				});
+				_wrapClasses += ' mfp-close-btn-in';
+			}
 		}
 
 		if(mfp.st.alignTop) {
@@ -275,12 +283,14 @@ MagnificPopup.prototype = {
 
 		
 
-		// Close on ESC key
-		_document.on('keyup' + EVENT_NS, function(e) {
-			if(e.keyCode === 27) {
-				mfp.close();
-			}
-		});
+		if(mfp.st.enableEscapeKey) {
+			// Close on ESC key
+			_document.on('keyup' + EVENT_NS, function(e) {
+				if(e.keyCode === 27) {
+					mfp.close();
+				}
+			});
+		}
 
 		_window.on('resize' + EVENT_NS, function() {
 			mfp.updateSize();
@@ -427,7 +437,8 @@ MagnificPopup.prototype = {
 		mfp.container.attr('class', 'mfp-container');
 
 		// remove close button from target element
-		if(!mfp.st.closeBtnInside || mfp.currTemplate[mfp.currItem.type] === true ) {
+		if(mfp.st.showCloseBtn &&
+		(!mfp.st.closeBtnInside || mfp.currTemplate[mfp.currItem.type] === true)) {
 			if(mfp.currTemplate.closeBtn)
 				mfp.currTemplate.closeBtn.detach();
 		}
@@ -526,7 +537,8 @@ MagnificPopup.prototype = {
 		mfp.content = newContent;
 		
 		if(newContent) {
-			if(mfp.st.closeBtnInside && mfp.currTemplate[type] === true) {
+			if(mfp.st.showCloseBtn && mfp.st.closeBtnInside &&
+				mfp.currTemplate[type] === true) {
 				// if there is no markup, we just append close button element inside
 				if(!mfp.content.find('.mfp-close').length) {
 					mfp.content.append(_getCloseBtn());
@@ -813,6 +825,12 @@ $.magnificPopup = {
 		closeOnBgClick: true,
 
 		closeBtnInside: true, 
+
+		showCloseBtn: true,
+
+		enableEscapeKey: true,
+
+		modal: false,
 
 		alignTop: false,
 	

--- a/website/_includes/examples.html
+++ b/website/_includes/examples.html
@@ -444,6 +444,39 @@ Each '.example' block contains JS, HTML and optionally CSS for popup.
 
 
   <div class="example gc3">
+    <h3>Modal popup</h3>
+    <p>A modal popup disables the usual ways to close popups.</p>
+    <div class="html-code">
+      <a class="popup-modal" href="#test-modal">Open modal</a>
+
+      <div id="test-modal" class="mfp-hide white-popup-block">
+        <h1>Modal dialog</h1>
+        <p>You won't be able to dismiss this by usual means (escape or
+          click button), but you can close it programatically based on
+          user choices or actions.</p>
+        <p><a class="popup-modal-dismiss" href="#">Dismiss</a></p>
+      </div>
+    </div>
+    <script type="text/javascript">
+      $(function () {
+        $('.popup-modal').magnificPopup({
+          type: 'inline',
+          preloader: false,
+          focus: '#username',
+          modal: true,
+        });
+        $(document).on('click', '.popup-modal-dismiss', function (e) {
+          e.preventDefault();
+          $.magnificPopup.close();
+        });
+      });
+    </script>
+  </div>
+
+
+
+
+  <div class="example gc3">
     <h3>Ajax popup</h3>
     <p>You have full control of what is displayed in popup, align it to any side via CSS, enable or disable scroll on right side of window - whatever.</p>
     <div class="html-code">

--- a/website/documentation.md
+++ b/website/documentation.md
@@ -570,6 +570,34 @@ Close the popup when user clicks on the dark overlay.
 
 If enabled, Magnific Popup will put close button inside content of popup, and wrapper will get class `mfp-close-btn-in` (which in default CSS file makes color of it change). If markup of popup item is defined element with class `mfp-close` will be replaced with this button, otherwise close button will be appended directly.
 
+
+### showCloseBtn
+
+<code class="def">true</code>
+
+Controls whether the close button will be displayed or not.
+
+
+### enableEscapeKey
+
+<code class="def">true</code>
+
+Controls whether pressing the escape key will dismiss the active popup or
+not.
+
+
+### modal
+
+<code class="def">false</code>
+
+When set to `true`, the popup will have a modal-like behavior: it won't be
+possible to dismiss it by usual means (close button, escape key, or
+clicking in the overlay).
+
+This is is a shortcut to set ``closeOnContentClick``, ``closeOnBgClick``,
+``showCloseBtn``, and ``enableEscapeKey`` to ``false``.
+
+
 ### alignTop
 
 <code class="def">false</code>


### PR DESCRIPTION
This adds three new options to enable modal-like behavior:
- `showCloseBtn`: Disables displaying the close button.
- `enableEscapeKey`: Disables dismissing popups by using the keyboard.
- `modal`: Enables modal behavior for a popup, so it's not dismissable by usual means. This is a synonym for setting `closeOnContentClick`, `closeOnBgClick`, `showCloseBtn`, and `enableEscapeKey` to `false`.
