### PR TITLE
A way to be notified of lazy loading failures

### DIFF
--- a/src/js/gallery.js
+++ b/src/js/gallery.js
@@ -167,6 +167,7 @@ $.magnificPopup.registerModule('gallery', {
 				}).on('error.mfploader', function() {
 					item.hasSize = true;
 					item.loadError = true;
+					_mfpTrigger('LazyLoadError', item);
 				}).attr('src', item.src);
 			}
 


### PR DESCRIPTION
Nice lightbox script!

I have a gallery of unknown length so I'm adding images dynamically as the user clicks through it (the URLs are like this: '/image?index=1'). 

To know when there are no more images I would like to use the lazy loading to preload the next few images and when reaching the end (which gives me a 404 error) remove that item (and any following) from the items array.

Is there currently any way of handling this?
If not I suggest adding the following 'LazyLoadError' event.

Cheers
Øyvind
