### PR TITLE
Changed "word-break" to "word-wrap"

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -451,7 +451,7 @@ button::-moz-focus-inner {
     text-align: left;
     line-height: 18px;
     color: $caption-title-color;
-    word-break: break-word;
+    word-wrap: break-word;
     padding-right: 36px; // leave some space for counter at right side
   }
 


### PR DESCRIPTION
"break-word" is an unsupported value for "word-break" property,
"word-wrap" is the the correct property for "break-word" value.
