### PR TITLE
Extended button reset to override Zurb Foundation presets

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -227,6 +227,8 @@ button.mfp-arrow {
   display: block;
   padding: 0;
   z-index: $z-index-base + 6;
+  -webkit-box-shadow: none;
+  box-shadow: none;
 }
 button::-moz-focus-inner {
     padding: 0;


### PR DESCRIPTION
Using Zurb Foundation as a base for your project means that buttons have box-shadow and -webkit-box-shadow defined. This means Magnific Popup navigation arrows have a narrow border above them. These extra lines in the reset stop this.
