### PR TITLE
use newer version of grunt-jekyll

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "grunt": "~0.4.0",
     "grunt-contrib-cssmin": "~0.4.1",
     "grunt-contrib-copy": "~0.4.0",
-    "grunt-jekyll": "~0.2.2",
+    "grunt-jekyll": "~0.3.9",
     "grunt-contrib-sass": "~0.2.2"
   }
 }


### PR DESCRIPTION
otherwise you get deprecation errors if you are using latest version of jekyll gem
