### PR TITLE
Bottom bar margin dependent on image padding

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -458,7 +458,7 @@ button::-moz-focus-inner {
     line-height: 0;
   }
   .mfp-bottom-bar {
-    margin-top:  -36px;
+    margin-top: -$image-padding-bottom + 4;
     position: absolute;
     top: 100%;
     left: 0;


### PR DESCRIPTION
I want to expand the bottom caption, because i have some multiline text.

You recommended, in issue #137, that you can "increase padding from bottom to give it some space". So I changed the `image-padding-bottom` variable in my `settings.scss` to `80px`, replacing the default `40px`. However, this left a large gap between the image and the caption text.

I inferred that the margin on top of the bottom bar was dependent on image padding. So I changed the value to reflect that, leaving the current `4px` of space between the image and the text.

If you have a better idea on how to increase the caption height, that would also work.
