### PR TITLE
Fixed a parsing error in libsass (dependency of grunt-sass)

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -86,7 +86,7 @@ $use-visuallyhidden:              false !default; // Hide content from browsers,
   background: $overlay-color;
   opacity: $overlay-opacity;
   @if $IE7support {
-    filter: alpha(opacity=$overlay-opacity*100);
+    filter: unquote("alpha(opacity=#{$overlay-opacity*100})");
   }
 }
 


### PR DESCRIPTION
Runing node-sass from nodejs throws a parsing error with the IE filter syntax. This change makes fixes the issue in libsass and still works in the ruby version of sass

/cc @pjackson28 
