### PR TITLE
Extract JSHint settings to .jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,21 @@
+{
+  "curly": false,
+  "eqeqeq": true,
+  "immed": true,
+  "latedef": true,
+  "newcap": true,
+  "noarg": true,
+  "sub": true,
+  "undef": false,
+  "unused": true,
+  "boss": true,
+  "eqnull": true,
+  "browser": true,
+
+  "predef": [
+    "define",
+    "module",
+    "mfp"
+  ],
+  "jquery": true
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,33 +42,14 @@ module.exports = function(grunt) {
     },
 
     jshint: {
-      all: ['Gruntfile.js', 'src/js/*.js'],
+      all: [
+        'Gruntfile.js',
+        'src/js/*.js'
+      ],
       options: {
-        "curly": false,
-        "eqeqeq": true,
-        "immed": true,
-        "latedef": true,
-        "newcap": true,
-        "noarg": true,
-        "sub": true,
-        "undef": false,
-        "unused": true,
-        "boss": true,
-        "eqnull": true,
-        "browser": true,
-
-        "predef": [
-          "jQuery",
-          "define",
-          "module",
-          "console",
-          "mfp",
-          "$"
-        ]
+        jshintrc: '.jshintrc'
       }
-
     },
-
 
     mfpbuild: {
       all: {


### PR DESCRIPTION
- Changed jQuery predefs to "jquery" flag
- Removed console predef since it was only used in commented out code

---

PS: bumping JSHint to the latest will produce the following errors

```
src\js\core.js: line 28, col 5, Redefinition of 'mfp'.
src\js\core.js: line 86, col 13, Read only.
```
