### PR TITLE
Removed outline on buttons

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -258,6 +258,7 @@ button {
     border: 0;
     -webkit-appearance: none;
     display: block;
+    outline: none;
     padding: 0;
     z-index: $z-index-base + 6;
     -webkit-box-shadow: none;


### PR DESCRIPTION
I can confirm that outline is appearing on close/next arrow/prev arrow buttons in the latest chrome version (on click), and I don't think it servers usability in this case.

Let me know what you think.
