### PR TITLE
Fix close button position with RTL direction

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -299,6 +299,12 @@ button {
     top: 1px;
   }
 }
+
+html[dir="rtl"] .mfp-close {
+  right: auto;
+  left: 0;
+}
+
 .mfp-close-btn-in {
   .mfp-close {
     color: $inner-close-icon-color;


### PR DESCRIPTION
The button should be left-aligned, otherwise wit will clash with the
right-aligned text.