### PR TITLE
Fixed figure margin (normalizing)

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -462,6 +462,7 @@ button {
 
   /* The shadow behind the image */
   .mfp-figure {
+    margin: 0;
     line-height: 0;
     &:after {
       content: '';


### PR DESCRIPTION
webkit applies some default margins to the `figure` element:

``` css
-webkit-margin-before: 1em;
-webkit-margin-after: 1em;
-webkit-margin-start: 40px;
-webkit-margin-end: 40px;
```

In order to use the library out of the box without any (not yet mentioned) third-party libraries the `figure` element has to be normalized by setting the margin to 0.
