### PR TITLE
added missing `-webkit-box-shadow`

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -433,6 +433,7 @@ button {
       left: 0;
       width: 100%;
       height: 100%;
+      -webkit-box-shadow: $shadow;
       box-shadow: $shadow;
       background: $iframe-background;
     }
@@ -474,6 +475,7 @@ button {
       width: auto;
       height: auto;
       z-index: -1;
+      -webkit-box-shadow: $shadow;
       box-shadow: $shadow;
       background: $image-background;
     }


### PR DESCRIPTION
`-webkit-box-shadow` is used on line 264, but missing in 436 and 479.
