### PR TITLE
Prevent gallery keyboard shortcuts when textarea or input has focus

### DIFF
--- a/src/js/gallery.js
+++ b/src/js/gallery.js
@@ -53,6 +53,7 @@ $.magnificPopup.registerModule('gallery', {
 				}
 
 				_document.on('keydown'+ns, function(e) {
+					if ( $("*:focus").is("textarea, input") ) return;
 					if (e.keyCode === 37) {
 						mfp.prev();
 					} else if (e.keyCode === 39) {


### PR DESCRIPTION
When you are in a gallery popup with Inline or AJAX content, trying to press left or right on the keyboard while typing in an input or textarea will trigger the gallery next/right functions. This prevents that.
