### PR TITLE
Change comment type to prevent empty CSS selector

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -546,7 +546,7 @@ button {
           }
         }
         .mfp-figure {
-          /* The shadow behind the image */
+          // The shadow behind the image
           &:after {
             top: 0;
             bottom: 0;


### PR DESCRIPTION
Sass will emit an empty CSS selector when an orphan rule contains a `/* */` comment block

---

Let me know if you want a built version with the PR, but it will remove this dead CSS rule https://github.com/dimsemenov/Magnific-Popup/blob/844ffea1c9e817b69eb3e5a46d4c2402cb835685/dist/magnific-popup.css#L312-L313
