### PR TITLE
Make Magnific Popup compatible with Turbolinks

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -139,7 +139,7 @@ MagnificPopup.prototype = {
 	 */
 	open: function(data) {
 
-		if(!_body) {
+		if(typeof Turbolinks !== "undefined" || !_body) {
 			_body = $(document.body);
 		}
 


### PR DESCRIPTION
Turbolinks is a JavaScript library that comes with Ruby on Rails 4. 

https://github.com/rails/turbolinks
>Turbolinks makes following links in your web application faster. Instead of letting the browser recompile the JavaScript and CSS between each page change, it keeps the current page instance alive and replaces only the body and the title in the head. Think CGI vs persistent process.

My problem is that Magnific Popup doesn't work with Turbolinks, which means that it is also incompatible with Ruby on Rails 4. 

On a Turbolinks-enabled web page, initially you can get a popup with Magnific Popup by clicking on a link. From a second try onward, however, clicking the same link does not bring up any popups.

It seems that caching $(document).body causes this problem. Magnific Popup is unaware of Turbolinks style page transitions and keeps old contents of the document.body element.

My workaround is shown in the sent commit. Probably, you will be able to come up with a better solution. My point is that I want to get Magnific Pop working properly with Turbolinks on Ruby on Rails.

Thank you very much in advance.