### PR TITLE
Prefix sass variables with 'mfp-' to prevent issues with own variables

### DIFF
--- a/src/css/_settings.scss
+++ b/src/css/_settings.scss
@@ -3,43 +3,43 @@
 ////////////////////////
 
 // overlay
-$overlay-color:                   #0b0b0b;                    // Color of overlay screen
-$overlay-opacity:                 0.8;                        // Opacity of overlay screen
-$shadow:                          0 0 8px rgba(0, 0, 0, 0.6); // Shadow on image or iframe
+$mfp-overlay-color:                   #0b0b0b;                    // Color of overlay screen
+$mfp-overlay-opacity:                 0.8;                        // Opacity of overlay screen
+$mfp-shadow:                          0 0 8px rgba(0, 0, 0, 0.6); // Shadow on image or iframe
 
 // spacing
-$popup-padding-left:              8px;                        // Padding from left and from right side
-$popup-padding-left-mobile:       6px;                        // Same as above, but is applied when width of window is less than 800px
+$mfp-popup-padding-left:              8px;                        // Padding from left and from right side
+$mfp-popup-padding-left-mobile:       6px;                        // Same as above, but is applied when width of window is less than 800px
 
-$z-index-base:                    1040;                        // Base z-index of popup
+$mfp-z-index-base:                    1040;                        // Base z-index of popup
 
 // controls
-$include-arrows:                  true;                       // Include styles for nav arrows
-$controls-opacity:                0.65;                       // Opacity of controls
-$controls-color:                  #FFF;                       // Color of controls
-$controls-border-color:           #3F3F3F; 	                  // Border color of controls
-$inner-close-icon-color:          #333;                       // Color of close button when inside
-$controls-text-color:             #CCC;                       // Color of preloader and "1 of X" indicator
-$controls-text-color-hover:       #FFF;                       // Hover color of preloader and "1 of X" indicator
-$IE7support:                      true;                       // Very basic IE7 support
+$mfp-include-arrows:                  true;                       // Include styles for nav arrows
+$mfp-controls-opacity:                0.65;                       // Opacity of controls
+$mfp-controls-color:                  #FFF;                       // Color of controls
+$mfp-controls-border-color:           #3F3F3F; 	                  // Border color of controls
+$mfp-inner-close-icon-color:          #333;                       // Color of close button when inside
+$mfp-controls-text-color:             #CCC;                       // Color of preloader and "1 of X" indicator
+$mfp-controls-text-color-hover:       #FFF;                       // Hover color of preloader and "1 of X" indicator
+$mfp-IE7support:                      true;                       // Very basic IE7 support
 
 // Iframe-type options
-$include-iframe-type:             true;                       // Enable Iframe-type popups
-$iframe-padding-top:              40px;                       // Iframe padding top
-$iframe-background:               #000;                       // Background color of iframes
-$iframe-max-width:                900px;                      // Maximum width of iframes
-$iframe-ratio:                    9/16;                       // Ratio of iframe (9/16 = widescreen, 3/4 = standard, etc.)
+$mfp-include-iframe-type:             true;                       // Enable Iframe-type popups
+$mfp-iframe-padding-top:              40px;                       // Iframe padding top
+$mfp-iframe-background:               #000;                       // Background color of iframes
+$mfp-iframe-max-width:                900px;                      // Maximum width of iframes
+$mfp-iframe-ratio:                    9/16;                       // Ratio of iframe (9/16 = widescreen, 3/4 = standard, etc.)
 
 // Image-type options
-$include-image-type:              true;                       // Enable Image-type popups
-$image-background:                #444 !default;
-$image-padding-top:               40px;                       // Image padding top
-$image-padding-bottom:            40px;                       // Image padding bottom
-$include-mobile-layout-for-image: true;                       // Removes paddings from top and bottom
+$mfp-include-image-type:              true;                       // Enable Image-type popups
+$mfp-image-background:                #444 !default;
+$mfp-image-padding-top:               40px;                       // Image padding top
+$mfp-image-padding-bottom:            40px;                       // Image padding bottom
+$mfp-include-mobile-layout-for-image: true;                       // Removes paddings from top and bottom
 
 // Image caption options
-$caption-title-color:             #F3F3F3;                    // Caption title color
-$caption-subtitle-color:          #BDBDBD;                    // Caption subtitle color
+$mfp-caption-title-color:             #F3F3F3;                    // Caption title color
+$mfp-caption-subtitle-color:          #BDBDBD;                    // Caption subtitle color
 
 // A11y
-$use-visuallyhidden:              false; 
+$mfp-use-visuallyhidden:              false; 

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -31,42 +31,42 @@
 // 1. Default Settings
 ////////////////////////
 
-$overlay-color:                   #0b0b0b !default;
-$overlay-opacity:                 0.8 !default;
-$shadow:                          0 0 8px rgba(0, 0, 0, 0.6) !default; // shadow on image or iframe
-$popup-padding-left:              8px !default; // Padding from left and from right side
-$popup-padding-left-mobile:       6px !default; // Same as above, but is applied when width of window is less than 800px
+$mfp-overlay-color:                   #0b0b0b !default;
+$mfp-overlay-opacity:                 0.8 !default;
+$mfp-shadow:                          0 0 8px rgba(0, 0, 0, 0.6) !default; // shadow on image or iframe
+$mfp-popup-padding-left:              8px !default; // Padding from left and from right side
+$mfp-popup-padding-left-mobile:       6px !default; // Same as above, but is applied when width of window is less than 800px
 
-$z-index-base:                    1040 !default; // Base z-index of popup
-$include-arrows:                  true !default; // include styles for nav arrows
-$controls-opacity:                0.65 !default;
-$controls-color:                  #FFF !default;
-$controls-border-color:           #3F3F3F !default;
-$inner-close-icon-color:          #333 !default;
-$controls-text-color:             #CCC !default; // Color of preloader and "1 of X" indicator
-$controls-text-color-hover:       #FFF !default;
-$IE7support:                      true !default; // Very basic IE7 support
+$mfp-z-index-base:                    1040 !default; // Base z-index of popup
+$mfp-include-arrows:                  true !default; // include styles for nav arrows
+$mfp-controls-opacity:                0.65 !default;
+$mfp-controls-color:                  #FFF !default;
+$mfp-controls-border-color:           #3F3F3F !default;
+$mfp-inner-close-icon-color:          #333 !default;
+$mfp-controls-text-color:             #CCC !default; // Color of preloader and "1 of X" indicator
+$mfp-controls-text-color-hover:       #FFF !default;
+$mfp-IE7support:                      true !default; // Very basic IE7 support
 
 // Iframe-type options
-$include-iframe-type:             true !default;
-$iframe-padding-top:              40px !default;
-$iframe-background:               #000 !default;
-$iframe-max-width:                900px !default;
-$iframe-ratio:                    9/16 !default;
+$mfp-include-iframe-type:             true !default;
+$mfp-iframe-padding-top:              40px !default;
+$mfp-iframe-background:               #000 !default;
+$mfp-iframe-max-width:                900px !default;
+$mfp-iframe-ratio:                    9/16 !default;
 
 // Image-type options
-$include-image-type:              true !default;
-$image-background:                #444 !default;
-$image-padding-top:               40px !default;
-$image-padding-bottom:            40px !default;
-$include-mobile-layout-for-image: true !default; // Removes paddings from top and bottom
+$mfp-include-image-type:              true !default;
+$mfp-image-background:                #444 !default;
+$mfp-image-padding-top:               40px !default;
+$mfp-image-padding-bottom:            40px !default;
+$mfp-include-mobile-layout-for-image: true !default; // Removes paddings from top and bottom
 
 // Image caption options
-$caption-title-color:             #F3F3F3 !default;
-$caption-subtitle-color:          #BDBDBD !default;
+$mfp-caption-title-color:             #F3F3F3 !default;
+$mfp-caption-subtitle-color:          #BDBDBD !default;
 
 // A11y
-$use-visuallyhidden:              false !default; // Hide content from browsers, but make it available for screen readers 
+$mfp-use-visuallyhidden:              false !default; // Hide content from browsers, but make it available for screen readers 
 
 
 
@@ -80,14 +80,14 @@ $use-visuallyhidden:              false !default; // Hide content from browsers,
   left: 0;
   width: 100%;
   height: 100%;
-  z-index: $z-index-base + 2;
+  z-index: $mfp-z-index-base + 2;
   overflow: hidden;
   position: fixed;
 
-  background: $overlay-color;
-  opacity: $overlay-opacity;
-  @if $IE7support {
-    filter: unquote("alpha(opacity=#{$overlay-opacity*100})");
+  background: $mfp-overlay-color;
+  opacity: $mfp-overlay-opacity;
+  @if $mfp-IE7support {
+    filter: unquote("alpha(opacity=#{$mfp-overlay-opacity*100})");
   }
 }
 
@@ -97,7 +97,7 @@ $use-visuallyhidden:              false !default; // Hide content from browsers,
   left: 0;
   width: 100%;
   height: 100%;
-  z-index: $z-index-base + 3;
+  z-index: $mfp-z-index-base + 3;
   position: fixed;
   outline: none !important;
   -webkit-backface-visibility: hidden; // fixes webkit bug that can cause "false" scrollbar
@@ -111,7 +111,7 @@ $use-visuallyhidden:              false !default; // Hide content from browsers,
   height: 100%;
   left: 0;
   top: 0;
-  padding: 0 $popup-padding-left;
+  padding: 0 $mfp-popup-padding-left;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
@@ -143,7 +143,7 @@ $use-visuallyhidden:              false !default; // Hide content from browsers,
   vertical-align: middle;
   margin: 0 auto;
   text-align: left;
-  z-index: $z-index-base + 5;
+  z-index: $mfp-z-index-base + 5;
 }
 .mfp-inline-holder,
 .mfp-ajax-holder {
@@ -193,7 +193,7 @@ $use-visuallyhidden:              false !default; // Hide content from browsers,
 }
 
 // Helper class that hides stuff
-@if $use-visuallyhidden {
+@if $mfp-use-visuallyhidden {
   // From HTML5 Boilerplate https://github.com/h5bp/html5-boilerplate/blob/v4.2.0/doc/css.md#visuallyhidden
   .mfp-hide {
     border: 0 !important;
@@ -218,7 +218,7 @@ $use-visuallyhidden:              false !default; // Hide content from browsers,
 
 // Preloader and text that displays error messages
 .mfp-preloader {
-  color: $controls-text-color;
+  color: $mfp-controls-text-color;
   position: absolute;
   top: 50%;
   width: auto;
@@ -226,11 +226,11 @@ $use-visuallyhidden:              false !default; // Hide content from browsers,
   margin-top: -0.8em;
   left: 8px;
   right: 8px;
-  z-index: $z-index-base + 4;
+  z-index: $mfp-z-index-base + 4;
   a {
-    color: $controls-text-color;
+    color: $mfp-controls-text-color;
     &:hover {
-      color: $controls-text-color-hover;
+      color: $mfp-controls-text-color-hover;
     }
   }
 }
@@ -261,7 +261,7 @@ button {
     display: block;
     outline: none;
     padding: 0;
-    z-index: $z-index-base + 6;
+    z-index: $mfp-z-index-base + 6;
     -webkit-box-shadow: none;
     box-shadow: none;
   }
@@ -283,12 +283,12 @@ button {
   top: 0;
   text-decoration: none;
   text-align: center;
-  opacity: $controls-opacity;
-  @if $IE7support {
-    filter: unquote("alpha(opacity=#{$controls-opacity*100})");
+  opacity: $mfp-controls-opacity;
+  @if $mfp-IE7support {
+    filter: unquote("alpha(opacity=#{$mfp-controls-opacity*100})");
   }
   padding: 0 0 18px 10px;
-  color: $controls-color;
+  color: $mfp-controls-color;
 
   font-style: normal;
   font-size: 28px;
@@ -297,7 +297,7 @@ button {
   &:hover,
   &:focus {
     opacity: 1;
-    @if $IE7support {
+    @if $mfp-IE7support {
       filter: unquote("alpha(opacity=#{1*100})");
     }
   }
@@ -308,13 +308,13 @@ button {
 }
 .mfp-close-btn-in {
   .mfp-close {
-    color: $inner-close-icon-color;
+    color: $mfp-inner-close-icon-color;
   }
 }
 .mfp-image-holder,
 .mfp-iframe-holder {
   .mfp-close {
-    color: $controls-color;
+    color: $mfp-controls-color;
     right: -6px;
     text-align: right;
     padding-right: 6px;
@@ -327,18 +327,18 @@ button {
   position: absolute;
   top: 0;
   right: 0;
-  color: $controls-text-color;
+  color: $mfp-controls-text-color;
   font-size: 12px;
   line-height: 18px;
 }
 
 // Navigation arrows
-@if $include-arrows {
+@if $mfp-include-arrows {
   .mfp-arrow {
     position: absolute;
-    opacity: $controls-opacity;
-    @if $IE7support {
-      filter: unquote("alpha(opacity=#{$controls-opacity*100})");
+    opacity: $mfp-controls-opacity;
+    @if $mfp-IE7support {
+      filter: unquote("alpha(opacity=#{$mfp-controls-opacity*100})");
     }
     margin: 0;
     top: 50%;
@@ -353,7 +353,7 @@ button {
     &:hover,
     &:focus {
       opacity: 1;
-      @if $IE7support {
+      @if $mfp-IE7support {
         filter: unquote("alpha(opacity=#{1*100})");
       }
     }
@@ -395,13 +395,13 @@ button {
 
     &:after,
     .mfp-a {
-      border-right: 17px solid $controls-color;
+      border-right: 17px solid $mfp-controls-color;
       margin-left: 31px;
     }
     &:before,
     .mfp-b {
       margin-left: 25px;
-      border-right: 27px solid $controls-border-color; 
+      border-right: 27px solid $mfp-controls-border-color; 
     }
   }
 
@@ -409,12 +409,12 @@ button {
     right: 0;
     &:after,
     .mfp-a {
-      border-left: 17px solid $controls-color;
+      border-left: 17px solid $mfp-controls-color;
       margin-left: 39px
     }
     &:before,
     .mfp-b {
-      border-left: 27px solid $controls-border-color;
+      border-left: 27px solid $mfp-controls-border-color;
     }
   }
 }
@@ -422,14 +422,14 @@ button {
 
 
 // Iframe content type
-@if $include-iframe-type {
+@if $mfp-include-iframe-type {
   .mfp-iframe-holder {
-    padding-top: $iframe-padding-top;
-    padding-bottom: $iframe-padding-top;
+    padding-top: $mfp-iframe-padding-top;
+    padding-bottom: $mfp-iframe-padding-top;
     .mfp-content {
       line-height: 0;
       width: 100%;
-      max-width: $iframe-max-width;
+      max-width: $mfp-iframe-max-width;
     }
     .mfp-close {
       top: -40px;
@@ -439,7 +439,7 @@ button {
     width: 100%;
     height: 0;
     overflow: hidden;
-    padding-top: $iframe-ratio * 100%;
+    padding-top: $mfp-iframe-ratio * 100%;
     iframe {
       position: absolute;
       display: block;
@@ -447,8 +447,8 @@ button {
       left: 0;
       width: 100%;
       height: 100%;
-      box-shadow: $shadow;
-      background: $iframe-background;
+      box-shadow: $mfp-shadow;
+      background: $mfp-iframe-background;
     }
   }
 }
@@ -456,7 +456,7 @@ button {
 
 
 // Image content type
-@if $include-image-type {
+@if $mfp-include-image-type {
 
   /* Main image in popup */
   img {
@@ -469,7 +469,7 @@ button {
       -webkit-box-sizing: border-box;
       -moz-box-sizing: border-box;
       box-sizing: border-box;
-      padding: $image-padding-top 0 $image-padding-bottom;
+      padding: $mfp-image-padding-top 0 $mfp-image-padding-bottom;
       margin: 0 auto;
     }
   }
@@ -481,18 +481,18 @@ button {
       content: '';
       position: absolute;
       left: 0;
-      top: $image-padding-top;
-      bottom: $image-padding-bottom;
+      top: $mfp-image-padding-top;
+      bottom: $mfp-image-padding-bottom;
       display: block;
       right: 0;
       width: auto;
       height: auto;
       z-index: -1;
-      box-shadow: $shadow;
-      background: $image-background;
+      box-shadow: $mfp-shadow;
+      background: $mfp-image-background;
     }
     small {
-      color: $caption-subtitle-color;
+      color: $mfp-caption-subtitle-color;
       display: block;
       font-size: 12px;
       line-height: 14px;
@@ -502,7 +502,7 @@ button {
     }
   }
   .mfp-bottom-bar {
-    margin-top: -$image-padding-bottom + 4;
+    margin-top: -$mfp-image-padding-bottom + 4;
     position: absolute;
     top: 100%;
     left: 0;
@@ -512,7 +512,7 @@ button {
   .mfp-title {
     text-align: left;
     line-height: 18px;
-    color: $caption-title-color;
+    color: $mfp-caption-title-color;
     word-wrap: break-word;
     padding-right: 36px; // leave some space for counter at right side
   }
@@ -532,7 +532,7 @@ button {
   }
 
 
-  @if $include-mobile-layout-for-image {
+  @if $mfp-include-mobile-layout-for-image {
     @media screen and (max-width: 800px) and (orientation:landscape), screen and (max-height: 300px) {
       /**
        * Remove all paddings around the image on small screen
@@ -609,8 +609,8 @@ button {
     transform-origin: 100%;
   }
   .mfp-container {
-    padding-left: $popup-padding-left-mobile;
-    padding-right: $popup-padding-left-mobile;
+    padding-left: $mfp-popup-padding-left-mobile;
+    padding-right: $mfp-popup-padding-left-mobile;
   }
 }
 
@@ -618,7 +618,7 @@ button {
 
 // IE7 support
 // Styles that make popup look nicier in old IE
-@if $IE7support {
+@if $mfp-IE7support {
   .mfp-ie7 {
     .mfp-img {
       padding: 0;


### PR DESCRIPTION
The SASS variables have currenlty names like $shadow.
If the SASS file is used as a partial the variables names
can collidate with own variable names. Therefore they
should be prefixed to make them more unique.
