### PR TITLE
Accessible close button (#23)

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -72,7 +72,7 @@ var _mfpOn = function(name, f) {
 	},
 	_getCloseBtn = function(type) {
 		if(type !== _currPopupType || !mfp.currTemplate.closeBtn) {
-			mfp.currTemplate.closeBtn = $( mfp.st.closeMarkup.replace('%title%', mfp.st.tClose ) );
+			mfp.currTemplate.closeBtn = $( mfp.st.closeMarkup.replace(/%title%/g, mfp.st.tClose ) );
 			_currPopupType = type;
 		}
 		return mfp.currTemplate.closeBtn;
@@ -890,7 +890,7 @@ $.magnificPopup = {
 
 		overflowY: 'auto',
 
-		closeMarkup: '<button title="%title%" type="button" class="mfp-close">&times;</button>',
+		closeMarkup: '<button title="%title%" type="button" class="mfp-close" aria-label="%title%"><span aria-hidden="true">&times;</span></button>',
 
 		tClose: 'Close (Esc)',
 


### PR DESCRIPTION
Use aria-label to provide alternative label for the close button. Hide
the &times; character with aria-hidden (otherwise, it is read as
"multiplication : button"). After the change, it is read as "Close (Esc) : button".
