### PR TITLE
Fix focusin in browsers which do not support it (#23)

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -358,8 +358,15 @@ MagnificPopup.prototype = {
 			}
 			
 			// Trap the focus in popup
-			_document.on('focusin' + EVENT_NS, mfp._onFocusIn);
-
+			if(!('onfocusin' in window) && document.addEventListener) {
+				// In browsers which do not support focusin but have
+				// addEventListener, fall back to focus with capture.
+				// Note: Some browsers do not have onfocusin even though they
+				// support focusin.
+				document.addEventListener('focus', mfp._onFocusIn, true);
+			} else {
+				_document.on('focusin' + EVENT_NS, mfp._onFocusIn);
+			}
 		}, 16);
 
 		mfp.isOpen = true;
@@ -418,6 +425,10 @@ MagnificPopup.prototype = {
 		
 		_document.off('keyup' + EVENT_NS + ' focusin' + EVENT_NS);
 		mfp.ev.off(EVENT_NS);
+
+		if(!('onfocusin' in window) && document.addEventListener) {
+			document.removeEventListener('focus', mfp._onFocusIn, true);
+		}
 
 		// clean up DOM elements that aren't removed
 		mfp.wrap.attr('class', 'mfp-wrap').removeAttr('style');


### PR DESCRIPTION
Some browsers do not support focusin (Firefox). When using framework
which does not provide its own implementation (zepto.js), tab
navigation is not confined to the dialog.

This fix falls back to a capturing focus event if it is supported by the
browser.

Caveats:
- The check for focusin support relies on window.onfocusin, which is
  not present in all browsers supporting focusin (notably Chrome).
  This should be OK, as addEventListener works in Chrome and IE does
  have window.onfocusin.
- The event needs to be removed manually by removeEventListener.

Tested in Firefox 28, Chromium 32, IE7/9/11.
