### PR TITLE
ARIA: Hide page content when popup is on (#23)

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -339,6 +339,16 @@ MagnificPopup.prototype = {
 
 		// remove scrollbar, add margin e.t.c
 		$('html').css(windowStyles);
+
+		// Add aria-hidden attributes to page elements, so that they are not
+		// accessible for as long as the popup is on.
+		// The original aria-hidden attributes (if any) are saved as
+		// data-aria-hidden, and resumed afterwards.
+		mfp._ariaHiddenElements = $('body').children();
+		$(mfp._ariaHiddenElements).each(function() {
+			$(this).attr('data-aria-hidden', $(this).attr('aria-hidden'));
+			$(this).attr('aria-hidden', 'true');
+		});
 		
 		// add everything to DOM
 		mfp.bgOverlay.add(mfp.wrap).prependTo( mfp.st.prependTo || _body );
@@ -423,6 +433,17 @@ MagnificPopup.prototype = {
 		mfp.wrap.attr('class', 'mfp-wrap').removeAttr('style');
 		mfp.bgOverlay.attr('class', 'mfp-bg');
 		mfp.container.attr('class', 'mfp-container');
+
+		// Remove aria-hidden attributes from page elements
+		$(mfp._ariaHiddenElements).each(function() {
+			if(typeof $(this).attr('data-aria-hidden') === 'undefined') {
+				$(this).removeAttr('aria-hidden');
+			} else {
+				$(this).attr('aria-hidden', $(this).attr('data-aria-hidden'));
+			}
+			$(this).removeAttr('data-aria-hidden');
+		});
+		mfp._ariaHiddenElements = [];
 
 		// remove close button from target element
 		if(mfp.st.showCloseBtn &&


### PR DESCRIPTION
When popup opens, tab navigation is confined to the dialog. However, all
page content is still accessible to screen readers, which do not know
that it has been occluded by an overlay. Without explicit aria-hidden
attributes, screen readers will navigate and read all of the page
content while the popup is on.

This fix adds aria-hidden attributes to all body child elements before
the popup is shown, and removes them when the popup is closed. Original
values (if present) are preserved in data-aria-hidden attributes.

Tested with ChromeVox on Chromium 32. Attributes are added and removed
correctly in Firefox 28 and IE9, but not tested with a screen reader.
