### PR TITLE
Update jquery.magnific-popup.js

### DIFF
--- a/dist/jquery.magnific-popup.js
+++ b/dist/jquery.magnific-popup.js
@@ -1090,7 +1090,7 @@ $.magnificPopup.registerModule(AJAX_NS, {
 				url: item.src,
 				success: function(data, textStatus, jqXHR) {
 					var temp = {
-						data:data,
+						data: '<div class="new-ajax-content">'+data+'</div>',
 						xhr:jqXHR
 					};
 


### PR DESCRIPTION
Ensure that the content from ajax request has a root element.
In some framework, like Symfony2, you can add some comment from the controller in the debug mode to help the developers to know which template is loaded. As the comments break Magnific Popup if they are outside the root element.
This PR fix the bug mentionned here : https://github.com/dimsemenov/Magnific-Popup/issues/34
