### PR TITLE
Check ancestors when close button is clicked

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -707,7 +707,7 @@ MagnificPopup.prototype = {
 	// "target" is an element that was clicked
 	_checkIfClose: function(target) {
 
-		if($(target).hasClass(PREVENT_CLOSE_CLASS)) {
+		if($(target).closest('.' + PREVENT_CLOSE_CLASS).length) {
 			return;
 		}
 
@@ -719,7 +719,7 @@ MagnificPopup.prototype = {
 		} else {
 
 			// We close the popup if click is on close button or on preloader. Or if there is no content.
-			if(!mfp.content || $(target).hasClass('mfp-close') || (mfp.preloader && target === mfp.preloader[0]) ) {
+			if(!mfp.content || $(target).closest('.mfp-close').length || (mfp.preloader && target === mfp.preloader[0]) ) {
 				return true;
 			}
 


### PR DESCRIPTION
In Chrome, if a user clicks on a `<button>` with child elements, the click target is the child element and not the `<button>` (if the user clicked precisely on the child element). See http://jsfiddle.net/jefferyto/MDCHj/ for a demo (try clicking on both the green `<button>` as well as the red inner `<i>` element).

This change checks the click target as well as its ancestors, when testing for classes. (A demo with this change is at http://jsfiddle.net/jefferyto/Jdg4E/2/)
