### PR TITLE
Update documentation.md

### DIFF
--- a/website/documentation.md
+++ b/website/documentation.md
@@ -562,7 +562,7 @@ Close the popup when user clicks on the dark overlay.
 
 ### closeBtnInside
 
-<code class="def">false</code>
+<code class="def">true</code>
 
 If enabled, Magnific Popup will put close button inside content of popup, and wrapper will get class `mfp-close-btn-in` (which in default CSS file makes color of it change). If markup of popup item is defined element with class `mfp-close` will be replaced with this button, otherwise close button will be appended directly.
 


### PR DESCRIPTION
`closeBtnInside` is currently set to `true` as default in [v0.9.9](https://github.com/dimsemenov/Magnific-Popup/blob/master/dist/jquery.magnific-popup.js#L879).
