### PR TITLE
allow counter update for inline elements

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -791,7 +791,9 @@ MagnificPopup.prototype = {
 				}
 
 			} else {
-				template.find(EVENT_NS + '-'+key).html(value);
+        try {
+          template.find(EVENT_NS + '-'+key).html(value);
+        } catch (e) { console.log(e); }
 			}
 		});
 	},

--- a/src/js/inline.js
+++ b/src/js/inline.js
@@ -55,6 +55,7 @@ $.magnificPopup.registerModule(INLINE_NS, {
 				}
 
 				item.inlineElement = el;
+        mfp._parseMarkup(el, {}, item);
 				return el;
 			}
 


### PR DESCRIPTION
this makes magnific popup update the "x of y" conter in inline items that contain an element of class mfp-counter

more rationale: http://stackoverflow.com/questions/25527101/magnific-popup-gallery-how-can-i-display-a-counter-in-an-inline-type-item/25580964
