### PR TITLE
Prevent word wrap in counter

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -330,6 +330,7 @@ button {
   color: $mfp-controls-text-color;
   font-size: 12px;
   line-height: 18px;
+  white-space: nowrap;
 }
 
 // Navigation arrows


### PR DESCRIPTION
When the text inside the counter is longer, e.g. `1 out of 3` instead of `1 of 3`, it can happen that the text inside gets wrapped. This is to prevent line breaks inside the counter element.
