### PR TITLE
Support require.js/AMD and CommonJS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -138,6 +138,9 @@ module.exports = function(grunt) {
             "if (typeof define === 'function' && define.amd) { \n" +
             " // AMD. Register as an anonymous module. \n" + 
             " define(['jquery'], factory); \n" + 
+            " } else if (typeof exports === 'object') { \n" +
+            " // Node/CommonJS \n" +
+            " factory(require('jquery')); \n" +
             " } else { \n" +
             " // Browser globals \n" +
             " factory(window.jQuery || window.Zepto); \n" +


### PR DESCRIPTION
This is along the lines of https://github.com/umdjs/umd/blob/master/jqueryPlugin.js

It allows to use different versions of jQuery in parallel and pass the correct one into MagnificPopup.
