### PR TITLE
Fix recognition of jquery to also work with non-global jQuery

### DIFF
--- a/dist/jquery.magnific-popup.js
+++ b/dist/jquery.magnific-popup.js
@@ -33,7 +33,7 @@ var CLOSE_EVENT = 'Close',
  */
 var mfp, // As we have only one instance of MagnificPopup object, we define it locally to not to use 'this'
 	MagnificPopup = function(){},
-	_isJQ = !!(window.jQuery),
+	_isJQ = !!($.fn.jquery),
 	_prevStatus,
 	_window = $(window),
 	_body,


### PR DESCRIPTION
When jquery is not attached globally (e.g when using `browserify` or `requirejs`), the previous detection for jQuery would fail and think it would be Zepto, even if jQuery is used. Since `$` is the local variable for jQuery/Zepto, this commit makes the distinction between jQuery and Zepto work with a non-global jQuery.

`$.fn.jquery` is undefined in Zepto, but in jQuery it returns the version number and thus the expression returns `true`.
