### PR TITLE
add grunt-contrib-copy dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "grunt-contrib-uglify": "~0.7.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-contrib-clean": "~0.6.0",
+    "grunt-contrib-copy": "~0.7.0",
     "grunt": "~0.4.5",
     "grunt-contrib-cssmin": "~0.11.0",
     "grunt": "~0.4.5",


### PR DESCRIPTION
When i clone repo, npm install and run grunt i have warnings:
```
hell:Magnific-Popup ruslan$ grunt
>> Local Npm module "grunt-contrib-copy" not found. Is it installed?
Warning: Task "copy" not found. Use --force to continue.

Aborted due to warnings.
```
After adding dependency, grunt tusk run successfully without this warning