### PR TITLE
Should return the module if in define.amd environment

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -184,7 +184,11 @@ module.exports = function(grunt) {
       newContents += grunt.file.read( basePath + name + '.js' ) + '\n';
       newContents += "\n/*>>"+name+"*/\n"; 
     });
-    newContents+= " _checkInstance(); }));";
+    newContents+= " _checkInstance();\n";
+    newContents+= " if (typeof define === 'function' && define.amd) {\n";
+    newContents+= "  return $.fn.magnificPopup;\n";
+    newContents+= " }\n";
+    newContents+= "\n}));";
 
     grunt.file.write( this.data.dest, newContents );
   });


### PR DESCRIPTION
If this plugin is used in a module environment (Require.js) it should return itself. It will be then possible to use it directly, without accessing it through the jQuery.fn namespace.

```javascript
define(["magnific-popup"], function(MFP) {
    // use MFP directly instead of $.fn.magnificPopup
});
```