### PR TITLE
Change mfp.updateItemHTML() position

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -164,11 +164,6 @@ MagnificPopup.prototype = {
 			mfp.index = data.index || 0;
 		}
 
-		// if popup is already opened - we just update the content
-		if(mfp.isOpen) {
-			mfp.updateItemHTML();
-			return;
-		}
 		
 		mfp.types = []; 
 		_wrapClasses = '';
@@ -200,6 +195,12 @@ MagnificPopup.prototype = {
 		}
 		
 
+		// if popup is already opened - we just update the content
+		if(mfp.isOpen) {
+			mfp.updateItemHTML();
+			return;
+		}
+		
 		// Building markup
 		// main containers are created only once
 		if(!mfp.bgOverlay) {


### PR DESCRIPTION
In case we just update the content, we still need to use the new settings in `data` variable. So `mfp.updateItemHTML();` should be called after `mfp.st = $.extend(true, {}, $.magnificPopup.defaults, data );`. (or the ajax request will use the old data)
I am not sure if this change is a good idea but it fixed by problem.
