### PR TITLE
Add "image" modules dependencies

### DIFF
--- a/website/_includes/build-tool.html
+++ b/website/_includes/build-tool.html
@@ -16,7 +16,7 @@
       <input type="checkbox" name="iframe" checked> Iframe
     </label>
     <label class="checkbox">
-      <input type="checkbox" name="gallery" checked> Gallery
+      <input type="checkbox" name="gallery" checked> Gallery (you need include Image)
     </label>
     <label class="checkbox">
       <input type="checkbox" name="retina" checked> High-DPI (retina) support for image type


### PR DESCRIPTION
If include "gallery" without "image", gallery doesn't work
