### PR TITLE
Update default closeMarkup value

### DIFF
--- a/website/documentation.md
+++ b/website/documentation.md
@@ -638,7 +638,7 @@ Delay before popup is removed from DOM. Used for the [animation](#animation).
 
 ### closeMarkup
 
-<code class="def">&lt;button title=&quot;%title%&quot; class=&quot;mfp-close&quot;&gt;&lt;i class=&quot;mfp-close-icn&quot;&gt;&amp;times;&lt;/i&gt;&lt;/button&gt;</code>
+<code class="def">&lt;button title=&quot;%title%&quot; type=&quot;button&quot; class=&quot;mfp-close&quot;&gt;&times;&lt;/button&gt;</code>
 
 Markup of close button. %title% will be replaced with option `tClose`.
 


### PR DESCRIPTION
When I was changing the closeMarkup value, I copied what's currently in the documentation, and it was very different from what was generated by default. It appears the the markup in the docs is out of date (for this option, at least).