### PR TITLE
Support for Shift + Click which opens href into new window

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -625,7 +625,7 @@ MagnificPopup.prototype = {
 		var midClick = options.midClick !== undefined ? options.midClick : $.magnificPopup.defaults.midClick;
 
 
-		if(!midClick && ( e.which === 2 || e.ctrlKey || e.metaKey ) ) {
+		if(!midClick && ( e.which === 2 || e.ctrlKey || e.metaKey || e.altKey || e.shiftKey ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fix for allow Shift + Click when midClick option is set to false. Shift + Click in browsers opens the href in a new window. Added altKey just as a precaution if a browser somewhere uses it. But if they don't then alt + click will do nothing, so i'm half/half on adding that. But in my production module i did add the altKey thing.