### PR TITLE
Sanitise attributes with jQuery

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -780,7 +780,7 @@ MagnificPopup.prototype = {
 						if(el.is('img')) {
 							el.attr('src', value);
 						} else {
-							el.replaceWith( '<img src="'+value+'" class="' + el.attr('class') + '" />' );
+							el.replaceWith( $('<img>').attr('src', value).attr('class', el.attr('class')) );
 						}
 					} else {
 						el.attr(arr[1], value);


### PR DESCRIPTION
In order to use this library on Wordpress VIP it has to pass through their security checks. They highlighted the use of unsanitised variables in the creation of the img element on line 783 of core.js as a problem that prevented us from using the code. This fix was what allowed me to deploy it.