### PR TITLE
Add 'style' property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "url": "https://github.com/dimsemenov/Magnific-Popup/issues"
   },
   "main": "dist/jquery.magnific-popup.js",
+  "style": "dist/magnific-popup.css",
   "homepage": "http://dimsemenov.com/plugins/magnific-popup/",
   "engines": {
     "node": ">= 0.8.0"


### PR DESCRIPTION
Many modules in npm are starting to expose their css entry files in their package.json files. This allows tools like `npm-css`, `rework-npm`, and `parcelify` to import styles from the node_modules directory.

(Shamelessly borrowed this description from @Techwraith 's great explanation from his bootstrap PR https://github.com/twbs/bootstrap/pull/12441 — which was successfully merged)

Easy merge. Please do. Thanks!