### PR TITLE
Resolves IE11 iframe Bug

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -339,7 +339,11 @@ MagnificPopup.prototype = {
 		mfp.bgOverlay.add(mfp.wrap).prependTo( mfp.st.prependTo || $(document.body) );
 
 		// Save last focused element
-		mfp._lastFocusedEl = document.activeElement;
+		try {
+			mfp._lastFocusedEl = document.activeElement;
+		} catch (error) {
+			mfp._lastFocusedEl = document.body;
+		}
 		
 		// Wait for next cycle to allow CSS transition
 		setTimeout(function() {


### PR DESCRIPTION
I've run into an Internet Explorer bug when using the library within an iframe. An error is thrown and code execution stops on [this line](https://github.com/dimsemenov/Magnific-Popup/blob/master/src/js/core.js#L342):

```js
mfp._lastFocusedEl = document.activeElement;
```

I found [this blog post](https://www.tjvantoll.com/2013/08/30/bugs-with-document-activeelement-in-internet-explorer/#accessing-documentactiveelement-from-an-iframe-in-ie9) which talks about a similar issue present in IE 9 (but claims it is not present in IE 10). To be clear: I've only confirmed that the bug is present in IE 11 and that this change fixes it, I have not tested IE 9 or 10.

