### PR TITLE
Added functionality to only present anchor tags that have an href poi…

### DIFF
--- a/dist/jquery.magnific-popup.js
+++ b/dist/jquery.magnific-popup.js
@@ -158,6 +158,18 @@ MagnificPopup.prototype = {
 		var i;
 
 		if(data.isObj === false) { 
+
+			//remove items where the href is empty.  EX. <a href="#" ... 
+			for(i = 0; i < data.items.length; i++){
+				item = data.items[i];
+				if( item.href.substr(item.href.length -1 , 1) === '#'){
+					//remove it
+					data.items.splice(i,1);
+					//decrement i because you just removed an element from the array.
+					i--;
+				}
+			}
+			
 			// convert jQuery collection to array to avoid conflicts later
 			mfp.items = data.items.toArray();
 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -141,6 +141,18 @@ MagnificPopup.prototype = {
 		var i;
 
 		if(data.isObj === false) { 
+
+			//remove items where the href is empty.  EX. <a href="#" ... 
+			for(i = 0; i < data.items.length; i++){
+				item = data.items[i];
+				if( item.href.substr(item.href.length -1 , 1) === '#'){
+					//remove it
+					data.items.splice(i,1);
+					//decrement i because you just removed an element from the array.
+					i--;
+				}
+			}
+
 			// convert jQuery collection to array to avoid conflicts later
 			mfp.items = data.items.toArray();
 


### PR DESCRIPTION
…nting to something


I thought it would be helpful to let the popups distinguish between empty <a> tags and <a> tags that actually pointed to content. This addition removes empty anchor tags from the popup gallery.


Previously:
<img width="1205" alt="screen shot 2017-04-03 at 9 33 11 pm" src="https://cloud.githubusercontent.com/assets/20466256/24639456/5777cd3e-18b5-11e7-8fe5-1f56f9d3fa02.png">

Now the images do not show, (they are removed from the data -> Items)

<img width="961" alt="screen shot 2017-04-03 at 9 41 55 pm" src="https://cloud.githubusercontent.com/assets/20466256/24639668/e4303ac6-18b6-11e7-90af-19be3dbf1317.png">

