### PR TITLE
Fix close button failure when closeMarkup contains nested nodes.

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -707,7 +707,7 @@ MagnificPopup.prototype = {
 		} else {
 
 			// We close the popup if click is on close button or on preloader. Or if there is no content.
-			if(!mfp.content || $(target).hasClass('mfp-close') || (mfp.preloader && target === mfp.preloader[0]) ) {
+			if(!mfp.content || $(target).closest('.mfp-close').length || (mfp.preloader && target === mfp.preloader[0]) ) {
 				return true;
 			}
 


### PR DESCRIPTION
Modify _checkIfClose to allow additional nodes inside .mfp-close when using custom closeMarkup.