### PR TITLE
Making isOpen = false more accurate after closing a modal

### DIFF
--- a/dist/jquery.magnific-popup.js
+++ b/dist/jquery.magnific-popup.js
@@ -388,15 +388,16 @@ MagnificPopup.prototype = {
 		if(!mfp.isOpen) return;
 		_mfpTrigger(BEFORE_CLOSE_EVENT);
 
-		mfp.isOpen = false;
 		// for CSS3 animation
 		if(mfp.st.removalDelay && !mfp.isLowIE && mfp.supportsTransition )  {
 			mfp._addClassToMFP(REMOVING_CLASS);
 			setTimeout(function() {
 				mfp._close();
+				mfp.isOpen = false;
 			}, mfp.st.removalDelay);
 		} else {
 			mfp._close();
+			mfp.isOpen = false;
 		}
 	},
 


### PR DESCRIPTION
I had an issue in the project I'm working on. We closed the modal and a backend process was so fast that when we tried to open again the modal it opened it and closed it immediately (invisible to us) because the setTimeout in close finished after we opened the new modal. This provoked our app inaccesible in the places the modal was shown. Typing in console isOpen it said true.

We were checking before opening the modal isOpen but it had false and we tried to open a new modal. With this change isOpen will be false when it has really close the modal. I hope you like this solution.
