### PR TITLE
pass event to disableOn handler

### DIFF
--- a/dist/jquery.magnific-popup.js
+++ b/dist/jquery.magnific-popup.js
@@ -642,7 +642,7 @@ MagnificPopup.prototype = {
 
 		if(disableOn) {
 			if($.isFunction(disableOn)) {
-				if( !disableOn.call(mfp) ) {
+				if( !disableOn.call(mfp, e) ) {
 					return true;
 				}
 			} else { // else it's number

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -625,7 +625,7 @@ MagnificPopup.prototype = {
 
 		if(disableOn) {
 			if($.isFunction(disableOn)) {
-				if( !disableOn.call(mfp) ) {
+				if( !disableOn.call(mfp, e) ) {
 					return true;
 				}
 			} else { // else it's number

--- a/website/documentation.md
+++ b/website/documentation.md
@@ -468,7 +468,7 @@ If window width is less than the number in this option lightbox will not be open
 Can also accept Function as a parameter, which should return `true` if lightbox can be opened and `false` otherwise. For example:
 
 {% highlight javascript %}
-disableOn: function() {
+disableOn: function(e) {
   if( $(window).width() < 600 ) {
     return false;
   }


### PR DESCRIPTION
Sometimes event in disableOn handler is need. For example if we need to disable popup when there is a disabled attribute on el that we clicked so we need to get element (e.target). (In the state when handler is called there is no el properties on instance.)