### PR TITLE
Break the 'broken image' example

### DIFF
--- a/website/_includes/examples.html
+++ b/website/_includes/examples.html
@@ -632,7 +632,7 @@ Each '.example' block contains JS, HTML and optionally CSS for popup.
     <p>This is just basic example of how error messages are displayed. Surely, you can change text or style them.</p>
     <div class="html-code">
       <!-- classes mfp-image and mfp-ajax define type of the popup -->
-      <a id="broken-image" class="mfp-image" href="http://upload.wikimedia.org/wikipedia/commons/thumb/f/f3/Blois_Loire_Panorama_-_July_2011.jpg/640px-Blois_Loire_Panorama_-_July_2011-fake.jpg" >Broken image</a><br/>
+      <a id="broken-image" class="mfp-image" href="non-existent.jpg" >Broken image</a><br/>
       <a id="broken-ajax" class="mfp-ajax" href="http://example.com/fakeg" >Broken ajax request</a>
     </div>
     <script type="text/javascript">


### PR DESCRIPTION
The previous URL (https://upload.wikimedia.org/wikipedia/commons/thumb/f/f3/Blois_Loire_Panorama_-_July_2011.jpg/640px-Blois_Loire_Panorama_-_July_2011-fake.jpg) in fact works now. Seems that Wikimedia's thumbnail rendering just uses the presence of the `640px` to resize. 

This PR changes the filename to that it's local to the documentation / website hosting; easier to ensure it stays broken.