### PR TITLE
Prevent setting alt=String("undefined") when the original IMG has no alt

### DIFF
--- a/src/js/image.js
+++ b/src/js/image.js
@@ -190,7 +190,11 @@ $.magnificPopup.registerModule('image', {
 				var img = document.createElement('img');
 				img.className = 'mfp-img';
 				if(item.el && item.el.find('img').length) {
-					img.alt = item.el.find('img').attr('alt');
+					// Sometimes the img does not have an alt attribute. jQuery 1.6+ will
+					// then return /undefined/, setting img.alt=String("undefined").
+					if(item.el.find('img').attr('alt')) {
+						img.alt = item.el.find('img').attr('alt');
+					}
 				}
 				item.img = $(img).on('load.mfploader', onLoadComplete).on('error.mfploader', onLoadError);
 				img.src = item.src;


### PR DESCRIPTION
As mentioned in #871, when using the Image type and the `<img>` has no `alt` attribute, Magnific Popup's [image.js on line 193](https://github.com/dimsemenov/Magnific-Popup/blob/c8f6b8549ebff2306c5f1179c9d112308185fe2c/src/js/image.js#L193) will erroneously replace the image with a new `img` where `alt=String("undefined")`.

**Problem line in Magnific Popup code (image.js:193):**
`img.alt = item.el.find('img').attr('alt');`

**Problem description:**
[As of jQuery version 1.6](http://api.jquery.com/attr/) (and Magnific Popup requires > 1.6) `jQuery.attr()` returns `undefined` if the attribute does not exist. When setting `img.alt = undefined`, undefined is converted to a String and the actual text "undefined" gets assigned.

**Proof of Underlying Problem (in jQuery):**
```
var img = document.createElement('img'), und = jQuery(img).attr('alt');
img.alt = und;
console.log(und, typeof und); // undefined "undefined"
console.log(img.alt, typeof img.alt); // "undefined" "string"
```

**Solution/Fix:**
Test `item.el.find('img').attr('alt')` before assigning `img.alt`, as done in this PR.