### PR TITLE
Update beforeClose callback core.js

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -368,8 +368,8 @@ MagnificPopup.prototype = {
 	 * Closes the popup
 	 */
 	close: function() {
-		if(!mfp.isOpen) return;
 		_mfpTrigger(BEFORE_CLOSE_EVENT);
+		if(!mfp.isOpen) return;
 
 		mfp.isOpen = false;
 		// for CSS3 animation


### PR DESCRIPTION
beforeClose event is useless being in turn for something IMO
Now ypu can easy lock closing modal inside by set this.isOpen=false/true