### PR TITLE
Adds mute to video iframe srcs to allow auto play

### DIFF
--- a/src/js/iframe.js
+++ b/src/js/iframe.js
@@ -34,12 +34,12 @@ $.magnificPopup.registerModule(IFRAME_NS, {
 			youtube: {
 				index: 'youtube.com',
 				id: 'v=',
-				src: '//www.youtube.com/embed/%id%?autoplay=1'
+				src: '//www.youtube.com/embed/%id%?autoplay=1&mute=1'
 			},
 			vimeo: {
 				index: 'vimeo.com/',
 				id: '/',
-				src: '//player.vimeo.com/video/%id%?autoplay=1'
+				src: '//player.vimeo.com/video/%id%?autoplay=1&muted=1'
 			},
 			gmaps: {
 				index: '//maps.google.',


### PR DESCRIPTION
The iframe src for both youtube and vimeo need to have mute added to allow auto play again. Issue #1111