### PR TITLE
Remove deprecated slash as div

### DIFF
--- a/src/css/_settings.scss
+++ b/src/css/_settings.scss
@@ -2,6 +2,8 @@
 //      Settings      //
 ////////////////////////
 
+@use 'sass:math';
+
 // overlay
 $mfp-overlay-color:                   #0b0b0b !default;                    // Color of overlay screen
 $mfp-overlay-opacity:                 0.8 !default;                        // Opacity of overlay screen
@@ -27,7 +29,7 @@ $mfp-include-iframe-type:             true !default;                       // En
 $mfp-iframe-padding-top:              40px !default;                       // Iframe padding top
 $mfp-iframe-background:               #000 !default;                       // Background color of iframes
 $mfp-iframe-max-width:                900px !default;                      // Maximum width of iframes
-$mfp-iframe-ratio:                    9/16 !default;                       // Ratio of iframe (9/16 = widescreen, 3/4 = standard, etc.)
+$mfp-iframe-ratio:                    math.div(9, 16) !default;            // Ratio of iframe (9/16 = widescreen, 3/4 = standard, etc.)
 
 // Image-type options
 $mfp-include-image-type:              true !default;                       // Enable Image-type popups


### PR DESCRIPTION
sass is deprecating use of slash as a division operator.
https://sass-lang.com/documentation/breaking-changes/slash-div

This change handles that deprecation.