### PR TITLE
Automatic RTL support and gallery non-loop option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Magnific Popup Repository (my fork with support for gallery arrows in Right-to-Left languages, i.e. Hebrew/Arabic)
+# Magnific Popup Repository
 
 [![Build Status](https://travis-ci.org/dimsemenov/Magnific-Popup.png)](https://travis-ci.org/dimsemenov/Magnific-Popup) 
 [![Flattr](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/thing/1310305/Magnific-Popup-by-dimsemenov)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Magnific Popup Repository
+# Magnific Popup Repository (my fork with support for gallery arrows in Right-to-Left languages, i.e. Hebrew/Arabic)
 
 [![Build Status](https://travis-ci.org/dimsemenov/Magnific-Popup.png)](https://travis-ci.org/dimsemenov/Magnific-Popup) 
 [![Flattr](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/thing/1310305/Magnific-Popup-by-dimsemenov)

--- a/src/js/gallery.js
+++ b/src/js/gallery.js
@@ -90,42 +90,42 @@ $.magnificPopup.registerModule('gallery', {
 			_mfpOn('BuildControls' + ns, function() {
 				if(mfp.items.length > 1 && gSt.arrows && !mfp.arrowLeft) {
 
-						var arrowLeftDesc, arrowRightDesc, arrowLeftAction, arrowRightAction;
+					var arrowLeftDesc, arrowRightDesc, arrowLeftAction, arrowRightAction;
 
-						if (gSt.langDir === 'rtl') {
-							arrowLeftDesc = gSt.tNext;
-							arrowRightDesc = gSt.tPrev;
-							arrowLeftAction = 'next';
-							arrowRightAction = 'prev';
-						} else {
-							arrowLeftDesc = gSt.tPrev;
-							arrowRightDesc = gSt.tNext;
-							arrowLeftAction = 'prev';
-							arrowRightAction = 'next';
-						}
+					if (gSt.langDir === 'rtl') {
+						arrowLeftDesc = gSt.tNext;
+						arrowRightDesc = gSt.tPrev;
+						arrowLeftAction = 'next';
+						arrowRightAction = 'prev';
+					} else {
+						arrowLeftDesc = gSt.tPrev;
+						arrowRightDesc = gSt.tNext;
+						arrowLeftAction = 'prev';
+						arrowRightAction = 'next';
+					}
 
-						var markup     = gSt.arrowMarkup,
-						    arrowLeft  = mfp.arrowLeft = $( markup.replace(/%title%/gi, arrowLeftDesc).replace(/%action%/gi, arrowLeftAction).replace(/%dir%/gi, 'left') ).addClass(PREVENT_CLOSE_CLASS),
-						    arrowRight = mfp.arrowRight = $( markup.replace(/%title%/gi, arrowRightDesc).replace(/%action%/gi, arrowRightAction).replace(/%dir%/gi, 'right') ).addClass(PREVENT_CLOSE_CLASS);
+					var markup     = gSt.arrowMarkup,
+					    arrowLeft  = mfp.arrowLeft = $( markup.replace(/%title%/gi, arrowLeftDesc).replace(/%action%/gi, arrowLeftAction).replace(/%dir%/gi, 'left') ).addClass(PREVENT_CLOSE_CLASS),
+					    arrowRight = mfp.arrowRight = $( markup.replace(/%title%/gi, arrowRightDesc).replace(/%action%/gi, arrowRightAction).replace(/%dir%/gi, 'right') ).addClass(PREVENT_CLOSE_CLASS);
 
-						if (gSt.langDir === 'rtl') {
-							mfp.arrowNext = arrowLeft;
-							mfp.arrowPrev = arrowRight;
-						} else {
-							mfp.arrowNext = arrowRight;
-							mfp.arrowPrev = arrowLeft;
-						}
+					if (gSt.langDir === 'rtl') {
+						mfp.arrowNext = arrowLeft;
+						mfp.arrowPrev = arrowRight;
+					} else {
+						mfp.arrowNext = arrowRight;
+						mfp.arrowPrev = arrowLeft;
+					}
 
-						arrowLeft.click(function() {
-							if (gSt.langDir === 'rtl') mfp.next();
-							else mfp.prev();
-						});
-						arrowRight.click(function() {
-							if (gSt.langDir === 'rtl') mfp.prev();
-							else mfp.next();
-						});
+					arrowLeft.click(function() {
+						if (gSt.langDir === 'rtl') mfp.next();
+						else mfp.prev();
+					});
+					arrowRight.click(function() {
+						if (gSt.langDir === 'rtl') mfp.prev();
+						else mfp.next();
+					});
 
-						mfp.container.append(arrowLeft.add(arrowRight));
+					mfp.container.append(arrowLeft.add(arrowRight));
 
 				}
 			});

--- a/src/js/gallery.js
+++ b/src/js/gallery.js
@@ -82,17 +82,23 @@ $.magnificPopup.registerModule('gallery', {
 			_mfpOn('BuildControls' + ns, function() {
 				if(mfp.items.length > 1 && gSt.arrows && !mfp.arrowLeft) {
 
+					var arrowLeftDesc, arrowRightDesc, arrowLeftAction, arrowRightAction;
+
 					if (gSt.langDir === 'rtl') {
-					    var arrowLeftDesc = gSt.tNext;
-					    var arrowRightDesc = gSt.tPrev;
+						arrowLeftDesc = gSt.tNext;
+						arrowRightDesc = gSt.tPrev;
+						arrowLeftAction = 'next';
+						arrowRightAction = 'prev';
 					} else {
-					    var arrowLeftDesc = gSt.tPrev;
-					    var arrowRightDesc = gSt.tNext;
+						arrowLeftDesc = gSt.tPrev;
+						arrowRightDesc = gSt.tNext;
+						arrowLeftAction = 'prev';
+						arrowRightAction = 'next';
 					}
 
-					var markup = gSt.arrowMarkup,
-						arrowLeft = mfp.arrowLeft = $( markup.replace(/%title%/gi, arrowLeftDesc).replace(/%dir%/gi, 'left') ).addClass(PREVENT_CLOSE_CLASS),
-						arrowRight = mfp.arrowRight = $( markup.replace(/%title%/gi, arrowRightDesc).replace(/%dir%/gi, 'right') ).addClass(PREVENT_CLOSE_CLASS);
+					var markup     = gSt.arrowMarkup,
+					    arrowLeft  = mfp.arrowLeft = $( markup.replace(/%title%/gi, arrowLeftDesc).replace(/%action%/gi, arrowLeftAction).replace(/%dir%/gi, 'left') ).addClass(PREVENT_CLOSE_CLASS),
+					    arrowRight = mfp.arrowRight = $( markup.replace(/%title%/gi, arrowRightDesc).replace(/%action%/gi, arrowRightAction).replace(/%dir%/gi, 'right') ).addClass(PREVENT_CLOSE_CLASS);
 
 					arrowLeft.click(function() {
 						if (gSt.langDir === 'rtl') mfp.next();

--- a/src/js/gallery.js
+++ b/src/js/gallery.js
@@ -25,7 +25,9 @@ $.magnificPopup.registerModule('gallery', {
 
 		tPrev: 'Previous (Left arrow key)',
 		tNext: 'Next (Right arrow key)',
-		tCounter: '%curr% of %total%'
+		tCounter: '%curr% of %total%',
+		
+		langDir: null,
 	},
 
 	proto: {
@@ -37,6 +39,10 @@ $.magnificPopup.registerModule('gallery', {
 			mfp.direction = true; // true - next, false - prev
 
 			if(!gSt || !gSt.enabled ) return false;
+			
+			if (!gSt.langDir) {
+				gSt.langDir = document.dir || 'ltr';
+			}
 
 			_wrapClasses += ' mfp-gallery';
 
@@ -53,9 +59,11 @@ $.magnificPopup.registerModule('gallery', {
 
 				_document.on('keydown'+ns, function(e) {
 					if (e.keyCode === 37) {
-						mfp.prev();
+						if (gSt.langDir === 'rtl') mfp.next();
+						else mfp.prev();
 					} else if (e.keyCode === 39) {
-						mfp.next();
+						if (gSt.langDir === 'rtl') mfp.prev();
+						else mfp.next();
 					}
 				});
 			});
@@ -78,10 +86,12 @@ $.magnificPopup.registerModule('gallery', {
 						arrowRight = mfp.arrowRight = $( markup.replace(/%title%/gi, gSt.tNext).replace(/%dir%/gi, 'right') ).addClass(PREVENT_CLOSE_CLASS);
 
 					arrowLeft.click(function() {
-						mfp.prev();
+						if (gSt.langDir === 'rtl') mfp.next();
+						else mfp.prev();
 					});
 					arrowRight.click(function() {
-						mfp.next();
+						if (gSt.langDir === 'rtl') mfp.prev();
+						else mfp.next();
 					});
 
 					mfp.container.append(arrowLeft.add(arrowRight));

--- a/src/js/gallery.js
+++ b/src/js/gallery.js
@@ -90,34 +90,43 @@ $.magnificPopup.registerModule('gallery', {
 			_mfpOn('BuildControls' + ns, function() {
 				if(mfp.items.length > 1 && gSt.arrows && !mfp.arrowLeft) {
 
-					var arrowLeftDesc, arrowRightDesc, arrowLeftAction, arrowRightAction;
+						var arrowLeftDesc, arrowRightDesc, arrowLeftAction, arrowRightAction;
 
-					if (gSt.langDir === 'rtl') {
-						arrowLeftDesc = gSt.tNext;
-						arrowRightDesc = gSt.tPrev;
-						arrowLeftAction = 'next';
-						arrowRightAction = 'prev';
-					} else {
-						arrowLeftDesc = gSt.tPrev;
-						arrowRightDesc = gSt.tNext;
-						arrowLeftAction = 'prev';
-						arrowRightAction = 'next';
-					}
+						if (gSt.langDir === 'rtl') {
+							arrowLeftDesc = gSt.tNext;
+							arrowRightDesc = gSt.tPrev;
+							arrowLeftAction = 'next';
+							arrowRightAction = 'prev';
+						} else {
+							arrowLeftDesc = gSt.tPrev;
+							arrowRightDesc = gSt.tNext;
+							arrowLeftAction = 'prev';
+							arrowRightAction = 'next';
+						}
 
-					var markup     = gSt.arrowMarkup,
-					    arrowLeft  = mfp.arrowLeft = $( markup.replace(/%title%/gi, arrowLeftDesc).replace(/%action%/gi, arrowLeftAction).replace(/%dir%/gi, 'left') ).addClass(PREVENT_CLOSE_CLASS),
-					    arrowRight = mfp.arrowRight = $( markup.replace(/%title%/gi, arrowRightDesc).replace(/%action%/gi, arrowRightAction).replace(/%dir%/gi, 'right') ).addClass(PREVENT_CLOSE_CLASS);
+						var markup     = gSt.arrowMarkup,
+						    arrowLeft  = mfp.arrowLeft = $( markup.replace(/%title%/gi, arrowLeftDesc).replace(/%action%/gi, arrowLeftAction).replace(/%dir%/gi, 'left') ).addClass(PREVENT_CLOSE_CLASS),
+						    arrowRight = mfp.arrowRight = $( markup.replace(/%title%/gi, arrowRightDesc).replace(/%action%/gi, arrowRightAction).replace(/%dir%/gi, 'right') ).addClass(PREVENT_CLOSE_CLASS);
 
-					arrowLeft.click(function() {
-						if (gSt.langDir === 'rtl') mfp.next();
-						else mfp.prev();
-					});
-					arrowRight.click(function() {
-						if (gSt.langDir === 'rtl') mfp.prev();
-						else mfp.next();
-					});
+						if (gSt.langDir === 'rtl') {
+							mfp.arrowNext = arrowLeft;
+							mfp.arrowPrev = arrowRight;
+						} else {
+							mfp.arrowNext = arrowRight;
+							mfp.arrowPrev = arrowLeft;
+						}
 
-					mfp.container.append(arrowLeft.add(arrowRight));
+						arrowLeft.click(function() {
+							if (gSt.langDir === 'rtl') mfp.next();
+							else mfp.prev();
+						});
+						arrowRight.click(function() {
+							if (gSt.langDir === 'rtl') mfp.prev();
+							else mfp.next();
+						});
+
+						mfp.container.append(arrowLeft.add(arrowRight));
+
 				}
 			});
 

--- a/src/js/gallery.js
+++ b/src/js/gallery.js
@@ -81,9 +81,18 @@ $.magnificPopup.registerModule('gallery', {
 
 			_mfpOn('BuildControls' + ns, function() {
 				if(mfp.items.length > 1 && gSt.arrows && !mfp.arrowLeft) {
+
+					if (gSt.langDir === 'rtl') {
+					    var arrowLeftDesc = gSt.tNext;
+					    var arrowRightDesc = gSt.tPrev;
+					} else {
+					    var arrowLeftDesc = gSt.tPrev;
+					    var arrowRightDesc = gSt.tNext;
+					}
+
 					var markup = gSt.arrowMarkup,
-						arrowLeft = mfp.arrowLeft = $( markup.replace(/%title%/gi, gSt.tPrev).replace(/%dir%/gi, 'left') ).addClass(PREVENT_CLOSE_CLASS),
-						arrowRight = mfp.arrowRight = $( markup.replace(/%title%/gi, gSt.tNext).replace(/%dir%/gi, 'right') ).addClass(PREVENT_CLOSE_CLASS);
+						arrowLeft = mfp.arrowLeft = $( markup.replace(/%title%/gi, arrowLeftDesc).replace(/%dir%/gi, 'left') ).addClass(PREVENT_CLOSE_CLASS),
+						arrowRight = mfp.arrowRight = $( markup.replace(/%title%/gi, arrowRightDesc).replace(/%dir%/gi, 'right') ).addClass(PREVENT_CLOSE_CLASS);
 
 					arrowLeft.click(function() {
 						if (gSt.langDir === 'rtl') mfp.next();

--- a/src/js/gallery.js
+++ b/src/js/gallery.js
@@ -148,16 +148,16 @@ $.magnificPopup.registerModule('gallery', {
 
 		},
 		next: function() {
-			mfp.direction = true;
 			var newIndex = _getLoopedId(mfp.index + 1);
 			if (!mfp.st.gallery.loop && newIndex === 0 ) return false;
+			mfp.direction = true;
 			mfp.index = newIndex;
 			mfp.updateItemHTML();
 		},
 		prev: function() {
-			mfp.direction = false;
 			var newIndex = mfp.index - 1;
 			if (!mfp.st.gallery.loop && newIndex < 0) return false;
+			mfp.direction = false;
 			mfp.index = _getLoopedId(newIndex);
 			mfp.updateItemHTML();
 		},

--- a/src/js/gallery.js
+++ b/src/js/gallery.js
@@ -28,6 +28,7 @@ $.magnificPopup.registerModule('gallery', {
 		tCounter: '%curr% of %total%',
 		
 		langDir: null,
+		loop: true,
 	},
 
 	proto: {
@@ -66,6 +67,13 @@ $.magnificPopup.registerModule('gallery', {
 						else mfp.next();
 					}
 				});
+
+				mfp.updateGalleryButtons();
+
+			});
+
+			_mfpOn('UpdateStatus'+ns, function(e, data) {
+				mfp.updateGalleryButtons();
 			});
 
 			_mfpOn('UpdateStatus'+ns, function(e, data) {
@@ -132,12 +140,16 @@ $.magnificPopup.registerModule('gallery', {
 		},
 		next: function() {
 			mfp.direction = true;
-			mfp.index = _getLoopedId(mfp.index + 1);
+			var newIndex = _getLoopedId(mfp.index + 1);
+			if (!mfp.st.gallery.loop && newIndex === 0 ) return false;
+			mfp.index = newIndex;
 			mfp.updateItemHTML();
 		},
 		prev: function() {
 			mfp.direction = false;
-			mfp.index = _getLoopedId(mfp.index - 1);
+			var newIndex = mfp.index - 1;
+			if (!mfp.st.gallery.loop && newIndex < 0) return false;
+			mfp.index = _getLoopedId(newIndex);
 			mfp.updateItemHTML();
 		},
 		goTo: function(newIndex) {
@@ -184,6 +196,26 @@ $.magnificPopup.registerModule('gallery', {
 
 
 			item.preloaded = true;
-		}
+		},
+
+		/**
+		 * Show/hide the gallery prev/next buttons if we're at the start/end, if looping is turned off
+		 * Added by Joloco for Veg
+		 */
+		updateGalleryButtons: function() {
+
+			if ( !mfp.st.gallery.loop && typeof mfp.arrowPrev === 'object' && mfp.arrowPrev !== null) {
+
+				if (mfp.index === 0) mfp.arrowPrev.hide();
+				else mfp.arrowPrev.show();
+
+				if (mfp.index === (mfp.items.length - 1)) mfp.arrowNext.hide();
+				else mfp.arrowNext.show();
+
+			}
+
+		},
+
 	}
+
 });


### PR DESCRIPTION
I'm developing a site in a right-to-left language (the main two are Arabic and Hebrew) and therefore the gallery next/prev buttons are the wrong way around -- for them, the left button should be "next" and the right button should be "prev".

The direction is discerned by checking `document.dir` and switching to RTL if the value there is "rtl" -- otherwise, the normal LTR behaviour is used.

The direction can be set explicitly using the "langDir" option when initialising the gallery.