### PR TITLE
allow mulitple instances of %id% in iframe src

### DIFF
--- a/src/js/iframe.js
+++ b/src/js/iframe.js
@@ -82,7 +82,7 @@ $.magnificPopup.registerModule(IFRAME_NS, {
 							embedSrc = this.id.call( this, embedSrc );
 						}
 					}
-					embedSrc = this.src.replace('%id%', embedSrc );
+					embedSrc = this.src.replace(/%id%/g, embedSrc );
 					return false; // break;
 				}
 			});


### PR DESCRIPTION
Passing in the same video id as a playlist parameter allows the video to loop. To do this we need multiple replacements of the `%id%`.

This PR simply changes this to a global string match so all instances of the `%id%` template is replaced.

eg.
https://www.youtube.com/embed/q3uXXh1sHcI?autoplay=1&loop=1&playlist=q3uXXh1sHcI