### PR TITLE
Mousedown/MouseUp  overlay problem

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -203,11 +203,11 @@ MagnificPopup.prototype = {
 		if(!mfp.bgOverlay) {
 
 			// Dark overlay
-			mfp.bgOverlay = _getEl('bg').on('click'+EVENT_NS, function() {
+			mfp.bgOverlay = _getEl('bg').on('mousedown'+EVENT_NS, function() {
 				mfp.close();
 			});
 
-			mfp.wrap = _getEl('wrap').attr('tabindex', -1).on('click'+EVENT_NS, function(e) {
+			mfp.wrap = _getEl('wrap').attr('tabindex', -1).on('mousedown'+EVENT_NS, function(e) {
 				if(mfp._checkIfClose(e.target)) {
 					mfp.close();
 				}


### PR DESCRIPTION
Fixed a bug when mouseDown occurs inside the popup, and mouseUp is outside and the popup closes.