### PR TITLE
replace deprecated (as per jQuery 3.x) methods -- fixes #1163

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -428,7 +428,7 @@ MagnificPopup.prototype = {
 
 
 		if(mfp.st.autoFocusLast && mfp._lastFocusedEl) {
-			$(mfp._lastFocusedEl).focus(); // put tab focus back
+			$(mfp._lastFocusedEl).trigger('focus'); // put tab focus back
 		}
 		mfp.currItem = null;	
 		mfp.content = null;
@@ -624,7 +624,7 @@ MagnificPopup.prototype = {
 		var disableOn = options.disableOn !== undefined ? options.disableOn : $.magnificPopup.defaults.disableOn;
 
 		if(disableOn) {
-			if($.isFunction(disableOn)) {
+			if(typeof disableOn === 'function') {
 				if( !disableOn.call(mfp) ) {
 					return true;
 				}
@@ -738,7 +738,7 @@ MagnificPopup.prototype = {
 		return (  (mfp.isIE7 ? _document.height() : document.body.scrollHeight) > (winHeight || _window.height()) );
 	},
 	_setFocus: function() {
-		(mfp.st.focus ? mfp.content.find(mfp.st.focus).eq(0) : mfp.wrap).focus();
+		(mfp.st.focus ? mfp.content.find(mfp.st.focus).eq(0) : mfp.wrap).trigger('focus');
 	},
 	_onFocusIn: function(e) {
 		if( e.target !== mfp.wrap[0] && !$.contains(mfp.wrap[0], e.target) ) {

--- a/src/js/gallery.js
+++ b/src/js/gallery.js
@@ -116,11 +116,11 @@ $.magnificPopup.registerModule('gallery', {
 						mfp.arrowPrev = arrowLeft;
 					}
 
-					arrowLeft.click(function() {
+					arrowLeft.on('click', function() {
 						if (gSt.langDir === 'rtl') mfp.next();
 						else mfp.prev();
 					});
-					arrowRight.click(function() {
+					arrowRight.on('click', function() {
 						if (gSt.langDir === 'rtl') mfp.prev();
 						else mfp.next();
 					});

--- a/src/js/image.js
+++ b/src/js/image.js
@@ -6,7 +6,7 @@ var _imgInterval,
 		var src = mfp.st.image.titleSrc;
 
 		if(src) {
-			if($.isFunction(src)) {
+			if(typeof src === 'function') {
 				return src.call(mfp, item);
 			} else if(item.el) {
 				return item.el.attr(src) || '';


### PR DESCRIPTION
Testing the code against the _jQuery Migrate Plugin_ (current version: 3.4.1) reveals a few deprecated functions. Accordingly,

- replace `.someUiEvent(func)` with `.on('someUiEvent', func)`
- replace `.someUiEvent()` with `.trigger('someUiEvent')`
- replace `.isFunction(arg)` with `typeoff arg === 'function'`
